### PR TITLE
Bump @contentful/rich-text-types to 16.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@becklyn/ui-types": "^5.0.0",
         "@contentful/rich-text-html-renderer": "^15.15.1",
-        "@contentful/rich-text-types": "^15.15.1",
+        "@contentful/rich-text-types": "^16.2.0",
         "contentful": "^9.3.3",
         "contentful-management": "^10.30.0",
         "contentful-migration": "^4.12.9",


### PR DESCRIPTION
While updating the contentful-adapter in Creditplus to the latest version I got strange Typescript errors:

```sh
Type error: Type 'BLOCKS.PARAGRAPH' is not assignable to type 'TopLevelBlockEnum'.

  36 |                                     },
  37 |                                 ],
> 38 |                                 nodeType: BLOCKS.PARAGRAPH,
     |                                 ^
  39 |                             },
  40 |                         ],
  41 |                         nodeType: BLOCKS.DOCUMENT,
  ```
(Note: `BLOCKS.PARAGRAPH` actually is `TopLevelBlockEnum` if you go-to-definition)

While testing I found out that the error did not appear if I imported both of the types directly from `@contentful/rich-text-types`. Maybe TS versions types internally? 

Manually bumping the `rich-text-types` version to the latest fixed it. Just bumping to the Creditplus version (`16.0.2`) did not work; some other package caused `16.2.0` to be installed. I can dig further here if wanted.
