### PR TITLE
Add optional variant type to social proof and rating slider blocks

### DIFF
--- a/src/migrations/components/blockRatingsSlider.ts
+++ b/src/migrations/components/blockRatingsSlider.ts
@@ -1,6 +1,14 @@
 import { ContentfulComponentMigrations, ContentfulMigrationGenerator } from "../types";
 import { migrateBaseBlockFields } from "./block";
-import { getRteValidation, RTE_TYPE_HEADLINE, RTE_TYPE_STYLED_FONT_AND_LIST } from "../rte";
+import { getRteValidation, RTE_TYPE_HEADLINE } from "../rte";
+import {
+    BLOCK_VARIANT_BLACK,
+    BLOCK_VARIANT_BRAND,
+    BLOCK_VARIANT_GRAY,
+    BLOCK_VARIANT_PRIMARY,
+    BLOCK_VARIANT_SECONDARY,
+    BLOCK_VARIANT_WHITE,
+} from "../constants/blockVariant";
 
 const translations = {
     en: {
@@ -9,6 +17,7 @@ const translations = {
             fields: {
                 headline: "Headline",
                 labeledLink: "Button",
+                variant: "Variant",
             },
         },
     },
@@ -18,6 +27,7 @@ const translations = {
             fields: {
                 headline: "Überschrift",
                 labeledLink: "Button",
+                variant: "Variante",
             },
         },
     },
@@ -64,6 +74,28 @@ export const getBlockRatingsSliderMigration: ContentfulMigrationGenerator = (
                 });
 
                 blockRatingsSlider.moveField("headline").afterField("name");
+            },
+            3: migration => {
+                const blockRatingsSlider = migration.editContentType("blockRatingsSlider");
+
+                blockRatingsSlider.createField("variant", {
+                    type: "Symbol",
+                    name: t.blockRatingsSlider.fields.variant,
+                    validations: [
+                        {
+                            in: [
+                                BLOCK_VARIANT_BRAND,
+                                BLOCK_VARIANT_PRIMARY,
+                                BLOCK_VARIANT_SECONDARY,
+                                BLOCK_VARIANT_WHITE,
+                                BLOCK_VARIANT_BLACK,
+                                BLOCK_VARIANT_GRAY,
+                            ],
+                        },
+                    ],
+                });
+
+                blockRatingsSlider.changeFieldControl("variant", "builtin", "dropdown");
             },
         },
     };

--- a/src/migrations/components/blockSocialProof.ts
+++ b/src/migrations/components/blockSocialProof.ts
@@ -1,6 +1,14 @@
 import { ContentfulComponentMigrations, ContentfulMigrationGenerator } from "../types";
 import { migrateBaseBlockFields } from "./block";
 import { getRteValidation, RTE_TYPE_HEADLINE } from "../rte";
+import {
+    BLOCK_VARIANT_BLACK,
+    BLOCK_VARIANT_BRAND,
+    BLOCK_VARIANT_GRAY,
+    BLOCK_VARIANT_PRIMARY,
+    BLOCK_VARIANT_SECONDARY,
+    BLOCK_VARIANT_WHITE,
+} from "../constants/blockVariant";
 
 const translations = {
     en: {
@@ -9,6 +17,7 @@ const translations = {
             fields: {
                 headline: "Headline",
                 entries: "Entries",
+                variant: "Variant",
             },
         },
         blockSocialProofEntry: {
@@ -26,6 +35,7 @@ const translations = {
             fields: {
                 headline: "Überschrift",
                 entries: "Einträge",
+                variant: "Variante",
             },
         },
         blockSocialProofEntry: {
@@ -111,6 +121,28 @@ export const getBlockSocialProofMigration: ContentfulMigrationGenerator = (
                 });
 
                 blockSocialProof.moveField("headline").afterField("name");
+            },
+            3: migration => {
+                const blockSocialProof = migration.editContentType("blockSocialProof");
+
+                blockSocialProof.createField("variant", {
+                    type: "Symbol",
+                    name: t.blockSocialProof.fields.variant,
+                    validations: [
+                        {
+                            in: [
+                                BLOCK_VARIANT_BRAND,
+                                BLOCK_VARIANT_PRIMARY,
+                                BLOCK_VARIANT_SECONDARY,
+                                BLOCK_VARIANT_WHITE,
+                                BLOCK_VARIANT_BLACK,
+                                BLOCK_VARIANT_GRAY,
+                            ],
+                        },
+                    ],
+                });
+
+                blockSocialProof.changeFieldControl("variant", "builtin", "dropdown");
             },
         },
     };

--- a/src/migrations/constants/blockVariant.ts
+++ b/src/migrations/constants/blockVariant.ts
@@ -1,0 +1,6 @@
+export const BLOCK_VARIANT_BRAND = "Brand";
+export const BLOCK_VARIANT_PRIMARY = "Primary";
+export const BLOCK_VARIANT_SECONDARY = "Secondary";
+export const BLOCK_VARIANT_WHITE = "White";
+export const BLOCK_VARIANT_BLACK = "Black";
+export const BLOCK_VARIANT_GRAY = "Gray";


### PR DESCRIPTION
Creditplus wants the background color for the SocialProof and RatingSlider Blocks to be configurable via Contentful. 

I added an optional `variant` field as a dropdown with some predefined values. The values will be associated with styles inside of the `theme.ts` in the actual project. For Creditplus, `mayd-ui` will take care of applying the styles to the blocks. Variants are super flexible and allow us to tweak lots of css properties at the same time (e.g background-color and color).

The predefined values are: `Brand`, `Primary`, `Secondary`, `White`, `Black`, `Gray`. 
