### PR TITLE
Allow RTE Icon on Block Text Image [req #9]

### DIFF
--- a/src/migrations/components/blockIconCards.ts
+++ b/src/migrations/components/blockIconCards.ts
@@ -10,6 +10,7 @@ const translations = {
                 overline: "Overline",
                 headline: "Headline",
                 entries: "Entries",
+                isSeoHeadline: "Is seo headline?",
             },
         },
         blockIconCardsEntry: {
@@ -29,6 +30,7 @@ const translations = {
                 overline: "Overline",
                 headline: "Überschrift",
                 entries: "Einträge",
+                isSeoHeadline: "Ist SEO Überschrift?",
             },
         },
         blockIconCardsEntry: {
@@ -130,6 +132,16 @@ export const getBlockIconCardsMigration: ContentfulMigrationGenerator = (
                 const blockIconCards = migration.editContentType("blockIconCards");
 
                 blockIconCards.moveField("headline").afterField("overline");
+            },
+            4: migration => {
+                const blockIconCards = migration.editContentType("blockIconCards");
+
+                blockIconCards.createField("isSeoHeadline", {
+                    type: "Boolean",
+                    name: t.blockIconCards.fields.isSeoHeadline,
+                });
+
+                blockIconCards.moveField("isSeoHeadline").beforeField("headline");
             },
         },
     };

--- a/src/migrations/components/blockTextImage.ts
+++ b/src/migrations/components/blockTextImage.ts
@@ -1,6 +1,11 @@
 import { ContentfulComponentMigrations, ContentfulMigrationGenerator } from "../types";
 import { migrateBaseBlockFields } from "./block";
-import { getRteValidation, RTE_TYPE_HEADLINE, RTE_TYPE_STYLED_FONT_AND_LIST } from "../rte";
+import {
+    getRteValidation,
+    RTE_TYPE_FULL,
+    RTE_TYPE_HEADLINE,
+    RTE_TYPE_STYLED_FONT_AND_LIST,
+} from "../rte";
 
 export const VERSION_BLOCK_TEXT_IMAGE = {
     en: {
@@ -165,6 +170,15 @@ export const getBlockTextImageMigration: ContentfulMigrationGenerator = (
                 });
 
                 blockTextImage.moveField("isSeoHeadline").beforeField("headline");
+            },
+            6: migration => {
+                const blockTextImage = migration.editContentType("blockTextImage");
+
+                blockTextImage.editField("text", {
+                    type: "RichText",
+                    name: t.blockTextImage.fields.text,
+                    validations: getRteValidation(RTE_TYPE_FULL),
+                });
             },
         },
     };

--- a/src/migrations/components/blockTextImage.ts
+++ b/src/migrations/components/blockTextImage.ts
@@ -32,6 +32,7 @@ const translations = {
                         VERSION_BLOCK_TEXT_IMAGE.en.imageRight,
                     ],
                 },
+                isSeoHeadline: "Is seo headline?",
             },
         },
     },
@@ -53,6 +54,7 @@ const translations = {
                         VERSION_BLOCK_TEXT_IMAGE.de.imageRight,
                     ],
                 },
+                isSeoHeadline: "Ist SEO Überschrift?",
             },
         },
     },
@@ -153,6 +155,16 @@ export const getBlockTextImageMigration: ContentfulMigrationGenerator = (
                 });
 
                 blockTextImage.moveField("secondaryLabeledLink").afterField("labeledLink");
+            },
+            5: migration => {
+                const blockTextImage = migration.editContentType("blockTextImage");
+
+                blockTextImage.createField("isSeoHeadline", {
+                    type: "Boolean",
+                    name: t.blockTextImage.fields.isSeoHeadline,
+                });
+
+                blockTextImage.moveField("isSeoHeadline").beforeField("headline");
             },
         },
     };

--- a/src/migrations/components/blockTextImage.ts
+++ b/src/migrations/components/blockTextImage.ts
@@ -37,7 +37,7 @@ const translations = {
                         VERSION_BLOCK_TEXT_IMAGE.en.imageRight,
                     ],
                 },
-                isSeoHeadline: "Is seo headline?",
+                isSeoHeadline: "Is SEO headline?",
             },
         },
     },


### PR DESCRIPTION
Update RTE validation on `text` field to allow content to contain RTE Icons. Builds upon #9 as both PRs hit the same Content-Type. 