### PR TITLE
Allow code embeds

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ export {
     RTE_TYPE_MINIMAL,
     RTE_TYPE_FULL,
     RTE_TYPE_TABLE,
+    RTE_TYPE_MARKS,
 } from "./migrations/rte";
 
 export { migrateBaseBlockFields } from "./migrations/components/block";

--- a/src/migrations/rte.ts
+++ b/src/migrations/rte.ts
@@ -7,6 +7,7 @@ export const RTE_TYPE_STYLED_FONT = "styled-font";
 export const RTE_TYPE_STYLED_FONT_AND_LIST = "styled-font-list";
 export const RTE_TYPE_FULL = "full";
 export const RTE_TYPE_TABLE = "table";
+export const RTE_TYPE_MARKS = "marks";
 
 export const getRteValidation = (version: string = RTE_TYPE_MINIMAL): Array<IValidation> => {
     if (version === RTE_TYPE_HEADLINE) {
@@ -28,8 +29,27 @@ export const getRteValidation = (version: string = RTE_TYPE_MINIMAL): Array<IVal
         ];
     }
 
+    if (version === RTE_TYPE_MARKS) {
+        return [
+            {
+                size: {
+                    max: 256,
+                },
+            },
+            {
+                enabledMarks: [MARKS.BOLD, MARKS.ITALIC, MARKS.UNDERLINE, MARKS.CODE],
+            },
+            {
+                enabledNodeTypes: [],
+            },
+            {
+                nodes: {},
+            },
+        ];
+    }
+
     const enabledMarks: string[] =
-        version !== RTE_TYPE_MINIMAL ? [MARKS.BOLD, MARKS.ITALIC, MARKS.UNDERLINE] : [];
+        version !== RTE_TYPE_MINIMAL ? [MARKS.BOLD, MARKS.ITALIC, MARKS.UNDERLINE, MARKS.CODE] : [];
 
     let enabledNodeTypes =
         version === RTE_TYPE_TABLE


### PR DESCRIPTION
Contentful sanitizes html characters like `&shy;` automatically, however they also automatically wrap it in a code block, which triggers their validation in the content UI. 

E.g `Filiale Mönchen&shy;glatbach` gets returned as `"Filiale Mönchen<code>&amp;shy;</code>gladbach"`, which is then (I assume because of the presence of `<code>`) throwing `Error: enabledMarks`. 

![image (1)](https://github.com/Becklyn-Studios/contentful-adapter/assets/24259317/20b625bf-d4aa-456e-8d36-648956cf2227)


Adding `MARKS.CODE` to the ´enabledMarks` fixes that. I added a new `RTE_TYPE` to isolate the change away from the type that I actually need: `RTE_TYPE_HEADLINE`.

  