### PR TITLE
(feature) 6.5.0 add Support for Ninetailed contentTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.5.0
+
+- (feature) Add support for Ninetailed contentTypes.
+
 # 6.4.5
 
 - (improvement) Allow marks to be set on RTE Icon text


### PR DESCRIPTION
Ninetailed content types can now be normalized automatically if the Entry has an Ninetailed field. The feature normalizes the Data our Component needs and denormalize the raw data the Ninetailed SDK needs for the Project.