### PR TITLE
normalize array relation type data with custom normalizer

### DIFF
--- a/src/data/relation.ts
+++ b/src/data/relation.ts
@@ -87,7 +87,7 @@ const normalizeArrayRelationTypeData = async (
     }
 
     if (isArray(relatedType)) {
-        let normalizedData: any[] = [];
+        const normalizedData: any[] = [];
 
         for (let i = 0; i < data.length; i++) {
             const normalized = await normalizeDynamicDataConfigData(relatedType, data[i], service);

--- a/src/data/relation.ts
+++ b/src/data/relation.ts
@@ -102,8 +102,8 @@ const normalizeArrayRelationTypeData = async (
                 service
             );
 
-            if (normalizedDataCustomNormalizer.length > 0) {
-                normalizedData = [...normalizedData, ...normalizedDataCustomNormalizer];
+            if (normalizedDataCustomNormalizer) {
+                normalizedData.push(normalizedDataCustomNormalizer);
             }
         }
 
@@ -208,8 +208,6 @@ const normalizeDynamicDataCustomNormalizer = async (
     fieldData: any,
     service: ContentfulNormalizerService
 ): Promise<any | null> => {
-    const normalizedData: any[] = [];
-
     for (const dataType of dataTypes) {
         const normalizer =
             "string" === typeof dataType ? service.getCustomNormalizer(dataType) : null;
@@ -218,10 +216,10 @@ const normalizeDynamicDataCustomNormalizer = async (
             const value = await normalizer(fieldData, service);
 
             if (value) {
-                normalizedData.push(value);
+                return value;
             }
         }
     }
 
-    return normalizedData;
+    return null;
 };


### PR DESCRIPTION
When inside component config, we have array with data types with custom normalizer, then it doesn't normalize data with custom normalizer. Because of that I have added to check if data use custom normalizer and normalize data.

For example this code didn't work:
`
internalLinks: {
    multiple: true,
    data: ["internal-reference"],
}
`
